### PR TITLE
Fixed ToArray functions

### DIFF
--- a/ClashRoyale/Extensions/ByteStream.cs
+++ b/ClashRoyale/Extensions/ByteStream.cs
@@ -794,8 +794,8 @@
         /// </summary>
         public byte[] ToArray()
         {
-            byte[] bytes = new byte[this.Offset];
-            Array.Copy(this.Buffer, 0, bytes, 0, this.Offset);
+            byte[] bytes = new byte[this.Length];
+            Array.Copy(this.Buffer, 0, bytes, 0, this.Length);
             return bytes;
         }
 
@@ -804,8 +804,8 @@
         /// </summary>
         public byte[] ToArray(int StartOffset)
         {
-            byte[] bytes = new byte[this.Offset - StartOffset];
-            Array.Copy(this.Buffer, StartOffset, bytes, 0, this.Offset - StartOffset);
+            byte[] bytes = new byte[this.Length - StartOffset];
+            Array.Copy(this.Buffer, StartOffset, bytes, 0, this.Length - StartOffset);
             return bytes;
         }
 


### PR DESCRIPTION
You was using this.Offset instead of this.Length, so it wasn't creating a byte array with the correct length but with the current offset, which isn't a length and same thing for the Array.Copy when it comes to set the "bytestocopy" Length parameter.